### PR TITLE
added ability to work in separate database 

### DIFF
--- a/openprocurement/planning/api/__init__.py
+++ b/openprocurement/planning/api/__init__.py
@@ -1,5 +1,6 @@
 from pyramid.events import ContextFound
-from openprocurement.planning.api.design import add_design
+
+from openprocurement.planning.api.design import add_design,add_design_db
 from openprocurement.planning.api.utils import plan_from_data, extract_plan, set_logging_context
 from logging import getLogger
 from pkg_resources import get_distribution
@@ -10,8 +11,27 @@ LOGGER = getLogger(PKG.project_name)
 
 
 def includeme(config):
-    LOGGER.info('init planing plugin')
-    add_design()
+
+    # config planning couchdb database
+    if hasattr(config.registry, 'couchdb_server') :
+        server = config.registry.couchdb_server  # current database
+        db_name = config.registry.db_name  # main database name
+        # planning database name - from config if exist, else same database
+        db_name_plan = config.get_settings().get('couchdb.db_name_plan') if config.get_settings().get('couchdb.db_name_plan') else db_name
+        # create additional database if does't exist
+        if db_name_plan not in server:
+            server.create(db_name_plan)
+        db_plan = server[db_name_plan]
+        # add planning database to registry
+        config.registry.db_plan = db_plan
+        LOGGER.info('init planing plugin with database [{}]'.format(db_plan.name))
+        # add design to separate database
+        add_design_db(db_plan)
+    else:
+        LOGGER.info('init planing plugin')
+        # add design
+        add_design()
+
     config.add_subscriber(set_logging_context, ContextFound)
     config.add_request_method(extract_plan, 'plan', reify=True)
     config.add_request_method(plan_from_data)

--- a/openprocurement/planning/api/design.py
+++ b/openprocurement/planning/api/design.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from couchdb.design import ViewDefinition
 from openprocurement.api import design
+from openprocurement.api.design import add_index_options
 
 
 FIELDS = [
@@ -16,6 +17,9 @@ def add_design():
         if "_view" in i:
             setattr(design, i, j)
 
+def add_design_db(db):
+    views = [j for i, j in globals().items() if "_view" in i]
+    ViewDefinition.sync_many(db, views, callback=add_index_options)
 
 plans_all_view = ViewDefinition('plans', 'all', '''function(doc) {
     if(doc.doc_type == 'Plan') {

--- a/openprocurement/planning/api/tests/base.py
+++ b/openprocurement/planning/api/tests/base.py
@@ -143,7 +143,8 @@ class BaseWebTest(unittest.TestCase):
         self.app.RequestClass = PrefixedRequestClass
         self.app.authorization = ('Basic', ('token', ''))
         self.couchdb_server = self.app.app.registry.couchdb_server
-        self.db = self.app.app.registry.db
+        self.db = self.app.app.registry.db_plan  if hasattr(self.app.app.registry, 'db_plan') else self.app.app.registry.db
+
 
     def tearDown(self):
         del self.couchdb_server[self.db.name]

--- a/openprocurement/planning/api/traversal.py
+++ b/openprocurement/planning/api/traversal.py
@@ -20,7 +20,7 @@ class Root(object):
 
     def __init__(self, request):
         self.request = request
-        self.db = request.registry.db
+        self.db = request.registry.db_plan  if hasattr(request.registry, 'db_plan') else request.registry.db
 
 
 def factory(request):

--- a/openprocurement/planning/api/utils.py
+++ b/openprocurement/planning/api/utils.py
@@ -63,8 +63,9 @@ def save_plan(request):
         plan.revisions.append(Revision({'author': request.authenticated_userid, 'changes': patch, 'rev': plan.rev}))
         old_date_modified = plan.dateModified
         plan.dateModified = get_now()
+        db = request.registry.db_plan  if hasattr(request.registry, 'db_plan') else request.registry.db
         try:
-            plan.store(request.registry.db)
+            plan.store(db)
         except ModelValidationError, e: # pragma: no cover
             for i in e.message:
                 request.errors.add('body', i, e.message[i])
@@ -117,7 +118,7 @@ def set_logging_context(event):
 
 
 def extract_plan_adapter(request, plan_id):
-    db = request.registry.db
+    db = request.registry.db_plan  if hasattr(request.registry, 'db_plan') else request.registry.db
     doc = db.get(plan_id)
     if doc is None:
         request.errors.add('url', 'plan_id', 'Not Found')

--- a/openprocurement/planning/api/views/plan.py
+++ b/openprocurement/planning/api/views/plan.py
@@ -54,7 +54,7 @@ class PlansResource(object):
     def __init__(self, request, context):
         self.request = request
         self.server = request.registry.couchdb_server
-        self.db = request.registry.db
+        self.db = request.registry.db_plan  if hasattr(request.registry, 'db_plan') else request.registry.db
         self.server_id = request.registry.server_id
 
     @json_view(permission='view_plan')


### PR DESCRIPTION
Для повноцінної роботи потрібен https://github.com/openprocurement/openprocurement.api/pull/36. Без пул-реквесту буде працювати як звично - у одній базі. Для вказання імені бази - потрібно у файлі openprocurement.api.ini добавити параметр couchdb.db_name_plan = plandb