### PR TITLE
plan revisions

### DIFF
--- a/openprocurement/planning/api/models.py
+++ b/openprocurement/planning/api/models.py
@@ -98,6 +98,7 @@ edit_role = (
     blacklist('owner_token', 'owner', '_attachments', 'revisions', 'dateModified', 'doc_id', 'planID', 'mode', '_attachments') + schematics_embedded_role)
 view_role = (blacklist('owner', 'owner_token', '_attachments', 'revisions') + schematics_embedded_role)
 listing_role = whitelist('dateModified', 'doc_id')
+revision_role = whitelist('revisions')
 Administrator_role = whitelist('status', 'mode', 'procuringEntity')
 
 
@@ -108,6 +109,7 @@ class Plan(SchematicsDocument, Model):
     class Options:
         roles = {
             'plain': plain_role,
+            'revision': revision_role,
             'create': create_role,
             'edit': edit_role,
             'view': view_role,

--- a/openprocurement/planning/api/tests/plan.py
+++ b/openprocurement/planning/api/tests/plan.py
@@ -563,6 +563,11 @@ class PlanResourceTest(BaseWebTest):
         self.assertEqual(revisions[-1][u'changes'][0]['op'], u'replace')
         self.assertEqual(revisions[-1][u'changes'][0]['path'], u'/budget/id')
 
+        response = self.app.get('/plans/{}/revisions'.format(plan['id']))
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['data']['revisions'], revisions)
+
         response = self.app.patch_json('/plans/{}'.format(
             plan['id']), {'data': {'items': [test_plan_data['items'][0]]}})
         self.assertEqual(response.status, '200 OK')

--- a/openprocurement/planning/api/traversal.py
+++ b/openprocurement/planning/api/traversal.py
@@ -13,6 +13,7 @@ class Root(object):
     __parent__ = None
     __acl__ = [
         (Allow, Everyone, 'view_plan'),
+        (Allow, Everyone, 'revision_plan'),
         (Allow, 'g:brokers', 'create_plan'),
         (Allow, 'g:brokers', 'edit_plan'),
         (Allow, 'g:Administrator', 'edit_plan'),

--- a/openprocurement/planning/api/views/plan_revision.py
+++ b/openprocurement/planning/api/views/plan_revision.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from openprocurement.planning.api.utils import (
+    opresource,
+    APIResource
+)
+from openprocurement.api.utils import (
+    json_view
+)
+
+@opresource(name='Plan Revisions',
+            collection_path='/plans/{plan_id}/revisions',
+            path='/plans/{plan_id}/revisions/{revision_id}',
+            description="Plan revisions")
+class PlansRevisionResource(APIResource):
+
+    @json_view(permission='revision_plan')
+    def collection_get(self):
+        """Plan Revisions List"""
+        plan = self.request.validated['plan']
+        plan_revisions = plan.serialize('revision')
+        return {'data': plan_revisions}


### PR DESCRIPTION
@myroslav На прохання Андрія - простий варіант отримання змін по плану (для відображення на порталі).
Окремий `GET api/0/plans/{plan_id}/revisions`, який поверне колекцію revisions, як є (сортування наче не потрібне, так як данні в масиві вже впорядковані по даті).
Далі на клієнті в js можна буде працювати з цим масивом по принципу jsonpatch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.planning.api/14)
<!-- Reviewable:end -->