### PR TITLE
fix error when root field classification is empty

### DIFF
--- a/openprocurement/planning/api/models.py
+++ b/openprocurement/planning/api/models.py
@@ -58,9 +58,10 @@ class PlanItem(Model):
     description_ru = StringType()
 
     def validate_classification(self, data, classification):
-        base_cpv_code = data['__parent__'].classification.id[:3]
-        if (base_cpv_code != classification.id[:3]):
-            raise ValidationError(u"CPV group of items be identical to root cpv")
+        if isinstance(data['__parent__'].classification, Model) :
+            base_cpv_code = data['__parent__'].classification.id[:3] if data['__parent__'].classification.id else None
+            if (base_cpv_code is not None and base_cpv_code != classification.id[:3]):
+                raise ValidationError(u"CPV group of items be identical to root cpv")
 
 
 class PlanOrganization(Model):


### PR DESCRIPTION
виявлено проблему - якщо при створенні плану не вказати classification, а присутні items[].classification, то виникає 500 помилка (у функції валідації items)